### PR TITLE
Fix python 3.10 compatibility

### DIFF
--- a/aioodbc/pool.py
+++ b/aioodbc/pool.py
@@ -44,7 +44,7 @@ class Pool(asyncio.AbstractServer):
         self._acquiring = 0
         self._recycle = pool_recycle
         self._free = collections.deque(maxlen=maxsize)
-        self._cond = asyncio.Condition(loop=loop)
+        self._cond = asyncio.Condition()
         self._used = set()
         self._closing = False
         self._closed = False


### PR DESCRIPTION
Parameter `pool` in asyncio.Condition is deprecated since 3.6 and removed in 3.10